### PR TITLE
Fix bounding rect miscalculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ## Upcoming release
 
+### Fixed
+
+- Fixed `boundingRect(with:options:)` miscalculation of `MessageLabel` , like text `Ꮚ˘̴͈́ꈊ˘̴͈̀Ꮚ⋆✩`、`Tomorrow is the day`.
+[#824](https://github.com/MessageKit/MessageKit/pull/824) by [@zhongwuzw](https://github.com/zhongwuzw).
+
 ### Changed
 
 - The `MessageData.emoji` case once again uses a default font of 2x the `messageLabelFont` size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The changelog for `MessageKit`. Also see the [releases](https://github.com/Messa
 
 ### Fixed
 
-- Fixed `boundingRect(with:options:)` miscalculation of `MessageLabel` , like text `Ꮚ˘̴͈́ꈊ˘̴͈̀Ꮚ⋆✩`、`Tomorrow is the day`.
+- Fixed `boundingRect(with:options:)` miscalculation of `MessageLabel` by using `NSLayoutManager`, like text `Ꮚ˘̴͈́ꈊ˘̴͈̀Ꮚ⋆✩`、`Tomorrow is the day`.
 [#824](https://github.com/MessageKit/MessageKit/pull/824) by [@zhongwuzw](https://github.com/zhongwuzw).
 
 ### Changed

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -24,6 +24,8 @@
 
 import Foundation
 
+private let additionalWidthForBoundingRectCalculation: CGFloat = 5.0
+
 open class MessageSizeCalculator: CellSizeCalculator {
 
     public init(layout: MessagesCollectionViewFlowLayout? = nil) {
@@ -216,8 +218,9 @@ open class MessageSizeCalculator: CellSizeCalculator {
     internal func labelSize(for attributedText: NSAttributedString, considering maxWidth: CGFloat) -> CGSize {
         let constraintBox = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
         let rect = attributedText.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).integral
-
-        return rect.size
+        
+        // `boundingRect` method maybe not calculate correctly, like `Ꮚ˘̴͈́ꈊ˘̴͈̀Ꮚ⋆✩`, so we add 5 points to fix them temporary.
+        return CGSize(width: rect.width + additionalWidthForBoundingRectCalculation, height: rect.height)
     }
 }
 

--- a/Sources/Layout/MessageSizeCalculator.swift
+++ b/Sources/Layout/MessageSizeCalculator.swift
@@ -24,8 +24,6 @@
 
 import Foundation
 
-private let additionalWidthForBoundingRectCalculation: CGFloat = 5.0
-
 open class MessageSizeCalculator: CellSizeCalculator {
 
     public init(layout: MessagesCollectionViewFlowLayout? = nil) {
@@ -51,6 +49,23 @@ open class MessageSizeCalculator: CellSizeCalculator {
 
     public var incomingMessageBottomLabelAlignment = LabelAlignment(textAlignment: .left, textInsets: UIEdgeInsets(left: 42))
     public var outgoingMessageBottomLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: UIEdgeInsets(right: 42))
+    
+    private lazy var textContainer: NSTextContainer = {
+        let textContainer = NSTextContainer()
+        textContainer.maximumNumberOfLines = 0
+        textContainer.lineFragmentPadding = 0
+        return textContainer
+    }()
+    private lazy var layoutManager: NSLayoutManager = {
+        let layoutManager = NSLayoutManager()
+        layoutManager.addTextContainer(textContainer)
+        return layoutManager
+    }()
+    private lazy var textStorage: NSTextStorage = {
+        let textStorage = NSTextStorage()
+        textStorage.addLayoutManager(layoutManager)
+        return textStorage
+    }()
 
     open override func configure(attributes: UICollectionViewLayoutAttributes) {
         guard let attributes = attributes as? MessagesCollectionViewLayoutAttributes else { return }
@@ -217,10 +232,14 @@ open class MessageSizeCalculator: CellSizeCalculator {
 
     internal func labelSize(for attributedText: NSAttributedString, considering maxWidth: CGFloat) -> CGSize {
         let constraintBox = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
-        let rect = attributedText.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).integral
         
-        // `boundingRect` method maybe not calculate correctly, like `Ꮚ˘̴͈́ꈊ˘̴͈̀Ꮚ⋆✩`, so we add 5 points to fix them temporary.
-        return CGSize(width: rect.width + additionalWidthForBoundingRectCalculation, height: rect.height)
+        textContainer.size = constraintBox
+        textStorage.replaceCharacters(in: NSRange(location: 0, length: textStorage.length), with: attributedText)
+        layoutManager.ensureLayout(for: textContainer)
+        
+        let size = layoutManager.usedRect(for: textContainer).size
+        
+        return CGSize(width: size.width.rounded(.up), height: size.height.rounded(.up))
     }
 }
 

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -172,7 +172,7 @@ open class MessageLabel: UILabel {
     open override func drawText(in rect: CGRect) {
 
         let insetRect = UIEdgeInsetsInsetRect(rect, textInsets)
-        textContainer.size = CGSize(width: insetRect.width, height: rect.height)
+        textContainer.size = CGSize(width: insetRect.width, height: insetRect.height)
 
         let origin = insetRect.origin
         let range = layoutManager.glyphRange(for: textContainer)


### PR DESCRIPTION
Fixes #812 #816 .
I think it's a bug for boundingRect(with:options:), it would calculates a less size when text like Ꮚ˘̴͈́ꈊ˘̴͈̀Ꮚ⋆✩ or Tomorrow is ....